### PR TITLE
Updated naming for onBackPressed.

### DIFF
--- a/app/src/main/java/com/badoo/tooltips/MainActivity.kt
+++ b/app/src/main/java/com/badoo/tooltips/MainActivity.kt
@@ -77,7 +77,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onBackPressed() {
-        if (!queue.onBackPressedHandled()) {
+        if (!queue.onBackPressed()) {
             super.onBackPressed()
         }
     }

--- a/tooltipsqueue/src/main/java/com/badoo/tooltipsqueue/PriorityTooltipsQueue.kt
+++ b/tooltipsqueue/src/main/java/com/badoo/tooltipsqueue/PriorityTooltipsQueue.kt
@@ -61,7 +61,7 @@ class PriorityTooltipsQueue(private val strategy: QueueStrategy = DefaultStrateg
         }
     }
 
-    override fun onBackPressedHandled(): Boolean {
+    override fun onBackPressed(): Boolean {
         onMainThread()
         val isShowing = behaviorSubject.valueNonNull != EmptyTooltip
         if (isShowing) {
@@ -115,6 +115,7 @@ class PriorityTooltipsQueue(private val strategy: QueueStrategy = DefaultStrateg
     }
 
     private fun add(tooltip: Tooltip) {
+        validateTooltip(tooltip::class.java)
         if (needToIgnoreAdded(tooltip)) {
             return
         }

--- a/tooltipsqueue/src/main/java/com/badoo/tooltipsqueue/TooltipsQueue.kt
+++ b/tooltipsqueue/src/main/java/com/badoo/tooltipsqueue/TooltipsQueue.kt
@@ -30,12 +30,10 @@ interface TooltipsQueue {
 
     /**
      * If currently you have tooltip on this screen, EmptyTooltip will be posted
-     * So it can help with implementing functionality with hiding tooltips after press on back button
-     *
-     * state of queue can be changed
-     * @return - true if is showing tooltip now, false otherwise
+     * Can be used for implementing functionality with hiding tooltips after press on back button
+     * @return - true (with EmptyTooltip posting) if is showing tooltip now, false otherwise
      */
-    fun onBackPressedHandled(): Boolean
+    fun onBackPressed(): Boolean
 
     /**
      * Start showing tooltips if queue is PAUSED, otherwise do nothing
@@ -53,8 +51,7 @@ interface TooltipsQueue {
     fun clear()
 
     /**
-     * Return all pending tooltips, that weren't shown.
-     * Useful to put pending tooltips in storage in case of activity destroy
+     * @return - all pending tooltips, that weren't shown.
      */
     fun pendingTooltips(): List<Tooltip>
 

--- a/tooltipsqueue/src/test/java/com/badoo/tooltipsqueue/PriorityTooltipsQueueTest.kt
+++ b/tooltipsqueue/src/test/java/com/badoo/tooltipsqueue/PriorityTooltipsQueueTest.kt
@@ -3,7 +3,6 @@ package com.badoo.tooltipsqueue
 import io.reactivex.observers.TestObserver
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -15,13 +14,10 @@ import java.util.concurrent.TimeUnit
 @Config(manifest = Config.NONE)
 class PriorityTooltipsQueueTest {
 
-    private lateinit var queue: TooltipsQueue
-    private lateinit var allTooltips: TestObserver<Tooltip>
+    private val queue: TooltipsQueue = PriorityTooltipsQueue()
+    private val allTooltips: TestObserver<Tooltip> = TestObserver()
 
-    @Before
-    fun setup() {
-        queue = PriorityTooltipsQueue()
-        allTooltips = TestObserver()
+    init {
         queue.onShow().subscribe(allTooltips)
     }
 
@@ -196,7 +192,7 @@ class PriorityTooltipsQueueTest {
     fun whenOnBackPressedWithEmptyTooltip_falseWillReturn() {
         queue.start()
 
-        assertEquals(false, queue.onBackPressedHandled())
+        assertEquals(false, queue.onBackPressed())
         assertEquals(1, allTooltips.valueCount())
     }
 
@@ -205,14 +201,14 @@ class PriorityTooltipsQueueTest {
         queue.start()
         queue.add(LowTooltip())
 
-        assertEquals(true, queue.onBackPressedHandled())
+        assertEquals(true, queue.onBackPressed())
     }
 
     @Test
     fun whenOnBackPressed_emptyWillBePosted() {
         queue.start()
         queue.add(LowTooltip())
-        queue.onBackPressedHandled()
+        queue.onBackPressed()
 
         allTooltips.assertValueAt(2) { isSameClass(EmptyTooltip, it) }
     }
@@ -222,6 +218,11 @@ class PriorityTooltipsQueueTest {
         queue.add(LowTooltip())
         queue.start()
         queue.remove(EmptyTooltip::class.java)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun whenAddEmpty_exceptionWillBeThrown() {
+        queue.add(EmptyTooltip)
     }
 
     @Test


### PR DESCRIPTION
Updated naming for onBackPressed.
Restricted adding EmptyTooltip to the queue to avoid unexpected behaviour.